### PR TITLE
changed payload object to submit "allycode" parameter key name

### DIFF
--- a/api-swgoh-help.js
+++ b/api-swgoh-help.js
@@ -237,7 +237,7 @@ module.exports = class SwgohHelp {
     
     async fetchPlayer( payload ) {
     	try {
-    		return await this.fetchAPI( this.player, payload );
+    		return await this.fetchAPI( this.player, { 'allycodes': payload } );
     	} catch(e) {
     		throw e;
     	}


### PR DESCRIPTION
API at https://api.swgoh.help/swgoh/players expects request body to be in the form { "allycodes" : Array<Number> } and rejects any request missing that parameter key name